### PR TITLE
Add MWTabFile.download_results_file() for programmatic results file download

### DIFF
--- a/src/mwtab/mwtab.py
+++ b/src/mwtab/mwtab.py
@@ -356,6 +356,64 @@ class MWTabFile(dict):
         """
         return self.get_table_as_pandas('Data')
     
+    def download_results_file(self, output_dir=".", session=None):
+        """Download the results file associated with this MWTabFile.
+
+        The results file URL is constructed from the study_id and analysis_id
+        properties, following the pattern:
+            https://www.metabolomicsworkbench.org/studydownload/{ST}_{AN}_Results.txt
+
+        :param str output_dir: Directory to save the results file to.
+        :param session: Optional requests.Session for connection pooling.
+        :return: Path to the downloaded file, or None if no results file info exists.
+        :rtype: str or None
+        """
+        import os
+        import requests
+
+        # Get IDs from managed properties
+        st_id = self.study_id
+        an_id = self.analysis_id
+
+        if not st_id or not an_id:
+            raise ValueError("MWTabFile must have both study_id and analysis_id to download results file")
+
+        # Check if results file info exists in MS or NM section
+        results_file_key = None
+        section_key = None
+        if 'MS' in self and 'MS_RESULTS_FILE' in self['MS']:
+            results_file_key = 'MS_RESULTS_FILE'
+            section_key = 'MS'
+        elif 'NM' in self and 'NMR_RESULTS_FILE' in self['NM']:
+            results_file_key = 'NMR_RESULTS_FILE'
+            section_key = 'NM'
+
+        if not results_file_key:
+            return None  # No results file info in this file
+
+        # Construct URL
+        base_url = "https://www.metabolomicsworkbench.org/studydownload/"
+        results_url = "{}{}_{}_Results.txt".format(base_url, st_id, an_id)
+
+        # Download
+        sess = session or requests.Session()
+        response = sess.get(results_url)
+        response.raise_for_status()
+
+        # Determine filename from results file dict if available
+        filename = None
+        if isinstance(self[section_key][results_file_key], dict) and "filename" in self[section_key][results_file_key]:
+            filename = self[section_key][results_file_key]["filename"]
+        else:
+            filename = "{}_{}_Results.txt".format(st_id, an_id)
+
+        output_path = os.path.join(output_dir, filename)
+
+        with open(output_path, 'wb') as f:
+            f.write(response.content)
+
+        return output_path
+
     def validate(self, ms_schema: dict = ms_required_schema, nmr_schema: dict = nmr_required_schema, verbose: bool = True) -> (str, list[dict]):
         """Validate the instance.
         

--- a/tests/test_download_results_file.py
+++ b/tests/test_download_results_file.py
@@ -1,0 +1,137 @@
+"""Tests for mwtab.mwtab module, specifically the download_results_file method."""
+
+import pytest
+from mwtab.mwtab import MWTabFile
+from unittest.mock import MagicMock
+
+
+class TestDownloadResultsFile:
+    """Test suite for MWTabFile.download_results_file() method."""
+    
+    def _create_mwfile_with_ids(self, st_id="ST000001", an_id="AN000001"):
+        """Helper to create a MWTabFile with study and analysis IDs."""
+        mwfile = MWTabFile("test_source")
+        mwfile["METABOLOMICS WORKBENCH"] = {
+            "STUDY_ID": st_id,
+            "ANALYSIS_ID": an_id,
+            "VERSION": "1",
+            "CREATED_ON": "2024-01-01"
+        }
+        return mwfile
+    
+    def test_download_results_file_ms_success(self, tmp_path, mocker):
+        """Test successful download of MS results file."""
+        mwfile = self._create_mwfile_with_ids("ST000001", "AN000001")
+        mwfile["MS"] = {
+            "MS_RESULTS_FILE": {
+                "filename": "ST000001_AN000001_Results.txt",
+                "UNITS": "Peak area",
+                "Has m/z": "Yes",
+                "Has RT": "Yes",
+                "RT units": "Minutes"
+            }
+        }
+        
+        mock_response = MagicMock()
+        mock_response.content = b"mock results data content"
+        mock_get = mocker.patch('requests.Session.get', return_value=mock_response)
+        
+        result = mwfile.download_results_file(output_dir=str(tmp_path))
+        
+        expected_path = str(tmp_path / "ST000001_AN000001_Results.txt")
+        assert result == expected_path
+        mock_get.assert_called_once_with(
+            "https://www.metabolomicsworkbench.org/studydownload/ST000001_AN000001_Results.txt"
+        )
+        
+        with open(expected_path, 'rb') as f:
+            assert f.read() == b"mock results data content"
+    
+    def test_download_results_file_nmr_success(self, tmp_path, mocker):
+        """Test successful download of NMR results file."""
+        mwfile = self._create_mwfile_with_ids("ST000002", "AN000002")
+        mwfile["NM"] = {
+            "NMR_RESULTS_FILE": {
+                "filename": "ST000002_AN000002_Results.txt"
+            }
+        }
+        
+        mock_response = MagicMock()
+        mock_response.content = b"nmr results data"
+        mock_get = mocker.patch('requests.Session.get', return_value=mock_response)
+        
+        result = mwfile.download_results_file(output_dir=str(tmp_path))
+        
+        expected_path = str(tmp_path / "ST000002_AN000002_Results.txt")
+        assert result == expected_path
+        mock_get.assert_called_once_with(
+            "https://www.metabolomicsworkbench.org/studydownload/ST000002_AN000002_Results.txt"
+        )
+    
+    def test_download_results_file_no_results_info(self, tmp_path):
+        """Test that None is returned when no results file info exists."""
+        mwfile = self._create_mwfile_with_ids("ST000003", "AN000003")
+        
+        result = mwfile.download_results_file(output_dir=str(tmp_path))
+        assert result is None
+    
+    def test_download_results_file_missing_study_id(self, tmp_path):
+        """Test that ValueError is raised when study_id is missing."""
+        mwfile = MWTabFile("test")
+        mwfile["METABOLOMICS WORKBENCH"] = {"ANALYSIS_ID": "AN000001"}
+        mwfile["MS"] = {"MS_RESULTS_FILE": {"filename": "test.txt"}}
+        
+        with pytest.raises(ValueError, match="study_id"):
+            mwfile.download_results_file(output_dir=str(tmp_path))
+    
+    def test_download_results_file_missing_analysis_id(self, tmp_path):
+        """Test that ValueError is raised when analysis_id is missing."""
+        mwfile = MWTabFile("test")
+        mwfile["METABOLOMICS WORKBENCH"] = {"STUDY_ID": "ST000001"}
+        mwfile["MS"] = {"MS_RESULTS_FILE": {"filename": "test.txt"}}
+        
+        with pytest.raises(ValueError, match="analysis_id"):
+            mwfile.download_results_file(output_dir=str(tmp_path))
+    
+    def test_download_results_file_uses_provided_session(self, tmp_path, mocker):
+        """Test that provided session is used instead of creating new one."""
+        mwfile = self._create_mwfile_with_ids("ST000004", "AN000004")
+        mwfile["MS"] = {"MS_RESULTS_FILE": {"filename": "test.txt"}}
+        
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = b"data"
+        mock_session.get.return_value = mock_response
+        
+        result = mwfile.download_results_file(output_dir=str(tmp_path), session=mock_session)
+        
+        mock_session.get.assert_called_once_with(
+            "https://www.metabolomicsworkbench.org/studydownload/ST000004_AN000004_Results.txt"
+        )
+        assert result is not None
+    
+    def test_download_results_file_http_error(self, tmp_path, mocker):
+        """Test that HTTP errors are properly raised."""
+        mwfile = self._create_mwfile_with_ids("ST000005", "AN000005")
+        mwfile["MS"] = {"MS_RESULTS_FILE": {"filename": "test.txt"}}
+        
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_get = mocker.patch('requests.Session.get', return_value=mock_response)
+        
+        with pytest.raises(Exception, match="404"):
+            mwfile.download_results_file(output_dir=str(tmp_path))
+    
+    def test_download_results_file_default_filename(self, tmp_path, mocker):
+        """Test that default filename is used when results file dict has no filename key."""
+        mwfile = self._create_mwfile_with_ids("ST000006", "AN000006")
+        mwfile["MS"] = {"MS_RESULTS_FILE": {"UNITS": "Peak area"}}
+        
+        mock_response = MagicMock()
+        mock_response.content = b"data"
+        mock_get = mocker.patch('requests.Session.get', return_value=mock_response)
+        
+        result = mwfile.download_results_file(output_dir=str(tmp_path))
+        
+        expected_path = str(tmp_path / "ST000006_AN000006_Results.txt")
+        assert result == expected_path


### PR DESCRIPTION
## Summary
The CLI supports `--results-files` but `MWTabFile` has no programmatic way to download results files. This PR adds `MWTabFile.download_results_file()` to fill that gap.

## Changes
- Added `download_results_file()` to `MWTabFile` class in `src/mwtab/mwtab.py`
- Uses existing `study_id` and `analysis_id` managed properties
- Supports both `MS_RESULTS_FILE` and `NMR_RESULTS_FILE` sections
- Allows optional `requests.Session` for connection pooling
- Falls back to default filename if results dict lacks `filename` key

## Tests
- 8 new test cases in `tests/test_download_results_file.py`
- All 330 tests pass (322 original + 8 new)

## Usage
```python
from mwtab import mwtab as mt
from mwtab import fileio, mwrest

url = mwrest.GenericMWURL({
    "context": "study",
    "input_item": "study_id", 
    "input_value": "ST000001",
    "output_item": "mwtab"
}).url

mwfile = next(fileio.read_with_class(url, mt.MWTabFile, {}))
path = mwfile.download_results_file(output_dir=".")